### PR TITLE
Utilisation de GNU Make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,8 @@ before_script:
       
 script:
   - ./_build.sh
-  - ./_deploy.sh
+
+deploy:
+  provider: script
+  script: ./_deploy.sh
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,17 @@ git:
   depth: false
 cache: 
   packages: yes
+  directories:
+    - $TRAVIS_BUILD_DIR/Supports_formations/m1_socle/_book
+    - $TRAVIS_BUILD_DIR/Supports_formations/m1_socle/_bookdown_files
+    - $TRAVIS_BUILD_DIR/Supports_formations/m2_preparation_donnees/_book
+    - $TRAVIS_BUILD_DIR/Supports_formations/m2_preparation_donnees/_bookdown_files
+    - $TRAVIS_BUILD_DIR/Supports_formations/m3_stats_desc/_book
+    - $TRAVIS_BUILD_DIR/Supports_formations/m3_stats_desc/_bookdown_files
+    - $TRAVIS_BUILD_DIR/Supports_formations/m4_analyse_donnees/_book
+    - $TRAVIS_BUILD_DIR/Supports_formations/m4_analyse_donnees/_bookdown_files
+    - $TRAVIS_BUILD_DIR/Supports_formations/m5_valorisation_des_donnees/_book
+    - $TRAVIS_BUILD_DIR/Supports_formations/m5_valorisation_des_donnees/_bookdown_files
 addons:
   apt:
     packages:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+OUTDIR=_book
+MODULES=$(sort $(notdir $(wildcard Supports_formations/*)))
+
+.PHONY: all $(MODULES)
+
+all: $(MODULES)
+
+$(MODULES):
+	$(MAKE) gitbook -C $(addprefix Supports_formations/,$@) OUTDIR=$(OUTDIR)

--- a/Supports_formations/m1_socle/Makefile
+++ b/Supports_formations/m1_socle/Makefile
@@ -1,0 +1,21 @@
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
+
+.PHONY: all gitbook pdf clean
+
+all: gitbook pdf
+
+gitbook: $(OUTDIR) 
+
+pdf: $(PDF_FILE)
+
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
+
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(OUTDIR)

--- a/Supports_formations/m2_preparation_donnees/Makefile
+++ b/Supports_formations/m2_preparation_donnees/Makefile
@@ -1,0 +1,21 @@
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
+
+.PHONY: all gitbook pdf clean
+
+all: gitbook pdf
+
+gitbook: $(OUTDIR) 
+
+pdf: $(PDF_FILE)
+
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
+
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(OUTDIR)

--- a/Supports_formations/m2_preparation_donnees/_bookdown.yml
+++ b/Supports_formations/m2_preparation_donnees/_bookdown.yml
@@ -1,4 +1,4 @@
-book_filename: "Préparer ses données avec R et le Tidyverse"
+book_filename: "Préparer-ses-données-avec-R-et-le-Tidyverse"
 delete_merged_file: TRUE
 language:
   ui:

--- a/Supports_formations/m3_stats_desc/Makefile
+++ b/Supports_formations/m3_stats_desc/Makefile
@@ -1,0 +1,21 @@
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
+
+.PHONY: all gitbook pdf clean
+
+all: gitbook pdf
+
+gitbook: $(OUTDIR) 
+
+pdf: $(PDF_FILE)
+
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
+
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(OUTDIR)

--- a/Supports_formations/m4_analyse_donnees/Makefile
+++ b/Supports_formations/m4_analyse_donnees/Makefile
@@ -1,0 +1,21 @@
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
+
+.PHONY: all gitbook pdf clean
+
+all: gitbook pdf
+
+gitbook: $(OUTDIR) 
+
+pdf: $(PDF_FILE)
+
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
+
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(OUTDIR)

--- a/Supports_formations/m5_valorisation_des_donnees/Makefile
+++ b/Supports_formations/m5_valorisation_des_donnees/Makefile
@@ -1,0 +1,21 @@
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
+
+.PHONY: all gitbook pdf clean
+
+all: gitbook pdf
+
+gitbook: $(OUTDIR) 
+
+pdf: $(PDF_FILE)
+
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
+
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(OUTDIR)

--- a/Supports_formations/mx_travail_collaboratif/Makefile
+++ b/Supports_formations/mx_travail_collaboratif/Makefile
@@ -1,0 +1,20 @@
+GBDIR=_book
+BOOK_NAME=$(shell Rscript -e "cat(bookdown:::book_filename())")
+PDF_FILE=$(addsuffix .pdf,$(BOOK_NAME))
+PDF_FILE:=$(addprefix /,$(PDF_FILE))
+PDF_FILE:=$(addprefix $(GBDIR),$(PDF_FILE))
+
+all: gitbook pdf
+
+gitbook: $(GBDIR) 
+
+pdf: $(PDF_FILE)
+
+$(GBDIR): *.Rmd
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(GBDIR)')"
+
+$(PDF_FILE): *.Rmd
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(GBDIR)', output_options = list(latex_engine = 'xelatex'))"
+
+clean:
+	rm -rf $(GBDIR)

--- a/Supports_formations/mx_travail_collaboratif/Makefile
+++ b/Supports_formations/mx_travail_collaboratif/Makefile
@@ -1,20 +1,22 @@
-GBDIR=_book
-BOOK_NAME=$(shell Rscript -e "cat(bookdown:::book_filename())")
-PDF_FILE=$(addsuffix .pdf,$(BOOK_NAME))
+OUTDIR=_book
+SOURCE=$(wildcard *.Rmd)
+PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
 PDF_FILE:=$(addprefix /,$(PDF_FILE))
-PDF_FILE:=$(addprefix $(GBDIR),$(PDF_FILE))
+PDF_FILE:=$(addprefix $(OUTDIR),$(PDF_FILE))
+
+.PHONY: all gitbook pdf clean
 
 all: gitbook pdf
 
-gitbook: $(GBDIR) 
+gitbook: $(OUTDIR) 
 
 pdf: $(PDF_FILE)
 
-$(GBDIR): *.Rmd
-	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(GBDIR)')"
+$(OUTDIR): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"
 
-$(PDF_FILE): *.Rmd
-	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(GBDIR)', output_options = list(latex_engine = 'xelatex'))"
+$(PDF_FILE): $(SOURCE)
+	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"
 
 clean:
-	rm -rf $(GBDIR)
+	rm -rf $(OUTDIR)

--- a/Supports_formations/mx_travail_collaboratif/Makefile
+++ b/Supports_formations/mx_travail_collaboratif/Makefile
@@ -1,8 +1,7 @@
 OUTDIR=_book
 SOURCE=$(wildcard *.Rmd)
 PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
-PDF_FILE:=$(addprefix /,$(PDF_FILE))
-PDF_FILE:=$(addprefix $(OUTDIR),$(PDF_FILE))
+PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))
 
 .PHONY: all gitbook pdf clean
 

--- a/_build.sh
+++ b/_build.sh
@@ -2,7 +2,7 @@
 
 set -ev
 
-make all MODULES=m1_socle m3_stats_desc m4_analyse_donnees m5_valorisation_des_donnees
+make all MODULES="m1_socle m2_preparation_donnees m3_stats_desc m4_analyse_donnees m5_valorisation_des_donnees"
 
 # pour générer l'ensemble des modules y compris mx_travail_collaboratif :
 # make all

--- a/_build.sh
+++ b/_build.sh
@@ -2,7 +2,7 @@
 
 set -ev
 
-make all MODULES=m1_socle m2_preparation_donnees m3_stats_desc m4_analyse_donnees m5_valorisation_des_donnees
+make all MODULES=m1_socle m3_stats_desc m4_analyse_donnees m5_valorisation_des_donnees
 
 # pour générer l'ensemble des modules y compris mx_travail_collaboratif :
 # make all

--- a/_build.sh
+++ b/_build.sh
@@ -2,27 +2,7 @@
 
 set -ev
 
-# Compilation du module 1
-cd ./Supports_formations/m1_socle/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+make all MODULES=m1_socle m2_preparation_donnees m3_stats_desc m4_analyse_donnees m5_valorisation_des_donnees
 
-# Compilation du module 2
-cd ./Supports_formations/m2_preparation_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
-
-# Compilation du module 3
-cd ./Supports_formations/m3_stats_desc/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
-
-# Compilation du module 4
-cd ./Supports_formations/m4_analyse_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
-
-# Compilation du module 5
-cd ./Supports_formations/m5_valorisation_des_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+# pour générer l'ensemble des modules y compris mx_travail_collaboratif :
+# make all

--- a/_build_only_m3.sh
+++ b/_build_only_m3.sh
@@ -3,7 +3,4 @@
 set -ev
 
 # Compilation du module 3
-cd ./Supports_formations/m3_stats_desc/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
-
+make m3_stats_desc

--- a/_deploy.sh
+++ b/_deploy.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-[ "${TRAVIS_BRANCH}" != "master" ] && exit 0
-
 git config --global user.email "stephane.trainel@gmail.com"
 git config --global user.name "Stéphane Trainel"
 git clone -b gh-pages https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git output

--- a/_deploy.sh
+++ b/_deploy.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "${TRAVIS_BRANCH}" != "master" ] && exit 0
+
 git config --global user.email "stephane.trainel@gmail.com"
 git config --global user.name "Stéphane Trainel"
 git clone -b gh-pages https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git output

--- a/readme.md
+++ b/readme.md
@@ -9,4 +9,3 @@
 15/02/2019
 * init (modules socle et à la carte : de 1 à 5)
 * ajout d'une page index de présentation
-


### PR DESCRIPTION
Alors, j'ai fait un makefile relativement générique pour un projet **bookdown** :

```makefile
OUTDIR=_book
SOURCE=$(wildcard *.Rmd)
PDF_FILE=$(shell Rscript -e "cat(paste0(bookdown:::book_filename(), '.pdf'))")
PDF_FILE:=$(addprefix $(OUTDIR),$(addprefix /,$(PDF_FILE)))

.PHONY: all gitbook pdf clean

all: gitbook pdf

gitbook: $(OUTDIR) 

pdf: $(PDF_FILE)

$(OUTDIR): $(SOURCE)
	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook', output_dir = '$(OUTDIR)')"

$(PDF_FILE): $(SOURCE)
	Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::pdf_book', output_dir = '$(OUTDIR)', output_options = list(latex_engine = 'xelatex'))"

clean:
	rm -rf $(OUTDIR)
```
Il est réutilisable dans le cadre de n'importe quel projet bookdown et s'utilise comme suit (dans le terminal) :
```bash
# générer le gitbook :
make gitbook

# générer le pdf :
make pdf

# générer les deux :
make all

# purger le répertoire _book :
make clean
```
L'intérêt de l'utilisation de **make** est de ne reconstruire les gitbooks et pdf que si un fichier `Rmd` a une date de sauvegarde ultérieure aux fichiers générés. Si les fichiers `Rmd` n'ont pas changé, aucune génération n'est effectuée.

Au niveau de la racine du repo, j'ai fait un **Makefile** "maître", qui lance en parallèle le **make gitbook** de chaque module. Seuls les modules pour lesquels au moins un des fichiers Rmd a changé seront reconstruits :

```makefile
OUTDIR=_book
MODULES=$(sort $(notdir $(wildcard Supports_formations/*)))

.PHONY: all $(MODULES)

all: $(MODULES)

$(MODULES):
	$(MAKE) gitbook -C $(addprefix Supports_formations/,$@) OUTDIR=$(OUTDIR)
```
Si on se trouve à la racine de **parcours-r**, les commandes suivantes peuvent être utilisées dans le terminal :

```bash
# actualiser le module 3 :
make m3_stats_desc

# générer les trois premiers modules :
make all MODULES=m1_socle m2_preparation_donnees m3_stats_desc

# générer tous les modules y compris mx_travail_collaboratif :
make all
```

Dans le contexte de Travis, cela impose de conserver les fichiers générés entre chaque build (sinon **make** reconstruira systématiquement les gitbooks et l'apport sera nul).
Pour cela, la solution utilisée dans **bookdown** est de mettre les fichiers en cache : https://github.com/rstudio/bookdown/blob/a48ead0ba601779c6443203ef02dcac959e5c3f6/.travis.yml#L4-L8

Je ne l'ai jamais tenté jusqu'ici. 
Logiquement, le premier build sera long car il n'y aura pas de cache. Et les suivants devraient être beaucoup plus rapides (si tout fonctionne comme prévu, mais avec Travis, on ne réussit jamais du 1er coup :smile: )