### PR TITLE
Render book maybe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
       - cargo
 
 before_script:
+  - chmod +x ./_render_book_maybe.R
   - chmod +x ./_build.sh
   - chmod +x ./_deploy.sh
       

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: Parcours-R
 Type: Book
 Title: Formations à R
 Version: 0.0.2
-Imports: rmarkdown, htmltools, tidyverse, cartography, sf, GGally, dplyr, plotly, bookdown, RcppRoll, DT, RPostgreSQL, rsdmx, XML, lsr, ggmosaic, visNetwork, FactoMineR, factoextra, ggExtra, kableExtra, hrbrthemes, tmap, highcharter, waffle, gganimate, svglite, cowplot, gifski
+Imports: rmarkdown, htmltools, tidyverse, cartography, sf, GGally, dplyr, plotly, bookdown, RcppRoll, DT, RPostgreSQL, rsdmx, XML, lsr, ggmosaic, visNetwork, FactoMineR, factoextra, ggExtra, kableExtra, hrbrthemes, tmap, highcharter, waffle, gganimate, svglite, cowplot, gifski, docopt
 License: MIT
 Description: Valise pédagogique pour la formation à R
 Authors@R: person("Stéphane", "Trainel", role = c("ctb", "cre"), email = "stephane.trainel@gmail.com", comment = c(ORCID = "0000-0002-4473-3121"))

--- a/_build.sh
+++ b/_build.sh
@@ -3,26 +3,16 @@
 set -ev
 
 # Compilation du module 1
-cd ./Supports_formations/m1_socle/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+./_render_book_maybe.R -f bookdown::gitbook  ./Supports_formations/m1_socle/
 
 # Compilation du module 2
-cd ./Supports_formations/m2_preparation_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+./_render_book_maybe.R -f bookdown::gitbook  ./Supports_formations/m2_preparation_donnees/
 
 # Compilation du module 3
-cd ./Supports_formations/m3_stats_desc/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+./_render_book_maybe.R -f bookdown::gitbook  ./Supports_formations/m3_stats_desc/
 
 # Compilation du module 4
-cd ./Supports_formations/m4_analyse_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+./_render_book_maybe.R -f bookdown::gitbook  ./Supports_formations/m4_analyse_donnees/
 
 # Compilation du module 5
-cd ./Supports_formations/m5_valorisation_des_donnees/
-Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"
-cd ../..
+./_render_book_maybe.R -f bookdown::gitbook  ./Supports_formations/m5_valorisation_des_donnees/

--- a/_render_book_maybe.R
+++ b/_render_book_maybe.R
@@ -1,0 +1,108 @@
+#!/usr/bin/env Rscript
+
+(function() {
+  
+  "Usage: 
+  render_book_maybe.R [-h] [-x] [--config_file=FILE] [--output_format=FORMAT] [--output_dir=DIR] [<dir>]
+  
+  -h --help                         show this help text
+  -x --usage                        show help and short example usage
+  dir                               directory of bookdown source files, current directory if omitted
+  -c FILE --config_file=FILE        configuration file in dir
+  -f FORMAT --output_format=FORMAT  output format passed to bookdown::render_book()
+  -o DIR --output_dir=DIR           output directory passed to bookdown::render_book(), default: _book" -> doc
+  
+  opt <- docopt::docopt(doc)
+  
+  if (opt$usage) {
+    cat(doc, "\n\n")
+    cat("Examples:
+        render_book_maybe.R                             # render bookdown in current directory
+        render_book_maybe.R dir                         # render bookdown in directory dir
+        render_book_maybe.R --config_file=_bookdown.yml # specify the configuration file
+        render_book_maybe.R -c _bookdown.yml            # specify the configuration file\n"
+    )
+    q("no")
+  }
+  
+  wd <- if (is.null(opt$dir)) "." else opt$dir
+  config_file <- if (is.null(opt$config_file)) "_bookdown.yml" else opt$config_file
+  
+  if (!dir.exists(wd)) {
+    stop("The argument must be a path to a directory.", call. = FALSE)
+  }
+  owd <- setwd(wd)
+  on.exit(setwd(owd))
+  
+  get_sha <- function(file) {
+    sha <- system2("git", c("log", "-n", "1", "--pretty=format:%H", "--", file), stdout = TRUE)
+    if (length(sha) < 1L) return("")
+    sha
+  }
+  
+  needs_build <- function(output_dir, config_file) {
+    source_files <- bookdown:::source_files(all = TRUE)
+    aux_files <- c(config_file, list.files(pattern = "^_output\\.yml$"))
+    tracked_files <- c(source_files, aux_files)
+    
+    current_sha <- vapply(tracked_files, get_sha, character(1), USE.NAMES = FALSE)
+    df <- as.data.frame(list(file = tracked_files, sha = current_sha), stringsAsFactors = FALSE)
+    
+    yes_build <- TRUE
+    attr(yes_build, "sha") <- df
+    
+    if (!dir.exists(output_dir)) {
+      message(output_dir, " does not exist. Bookdown needs to be built.")
+      return(yes_build)
+    }
+    
+    stored_sha <- file.path(output_dir, "sha.csv")
+    if (file.exists(stored_sha)) {
+      prev_sha <- read.csv(stored_sha, stringsAsFactors = FALSE)
+    } else {
+      message("Cannot find ", stored_sha, " file. Bookdown needs to be built.")
+      return(yes_build)
+    }
+    
+    if (!identical(colnames(prev_sha), c("file", "sha"))) {
+      message(stored_sha, ": wrong file format.")
+      return(yes_build)
+    }
+    
+    merged <- merge(prev_sha, df, by.x = "file", by.y = "file", all = TRUE)
+    if (isTRUE(all(merged$sha.x == merged$sha.y))) {
+      return(FALSE)
+    } else {
+      message("Source files have changed.")
+      return(yes_build)
+    }
+  }
+  
+  render_book_maybe <- function(
+    input, output_format = NULL, ..., output_dir = NULL, 
+    config_file = "_bookdown.yml", envir = globalenv()
+  ) {
+    bookdown:::opts$set(config = rmarkdown:::yaml_load_file(config_file))
+    output_dir <- bookdown:::output_dirname(output_dir, create = FALSE)
+    csv_path <- file.path(output_dir, "sha.csv")
+    to_build <- needs_build(output_dir, config_file)
+    
+    if (to_build) {
+      bookdown::render_book(input = input, 
+                            output_format = output_format, 
+                            output_dir = output_dir, 
+                            config_file = config_file, 
+                            envir = envir, 
+                            ...)
+      write.csv(attr(to_build, "sha"), csv_path, row.names = FALSE)
+    }
+    else {
+      message("No source file have changed.")
+    }
+  }
+  
+  render_book_maybe(
+    input = ".", output_format = opt$output_format, 
+    output_dir = opt$output_dir, config_file = config_file
+  )
+})()


### PR DESCRIPTION
The aim of this PR is to build each bookdown book only when one of its source files has been modified.  
With `git`, the modification dates of the files cannot be used. So we cannot rely on `make`.

The `_render_book_maybe.R` script checks the `sha` of the last commit for each `Rmd` file and save it in the bookdown output directory.
`bookdown::render_book()` is executed only if one `sha` differs (or if there is a new `Rmd` file).

This script has to be used with Travis cache (this is the case here).